### PR TITLE
Update python runtime environments


### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
-- '2.7'
-- '3.3'
-- '3.4'
 - '3.5'
+- '3.6'
+- '3.7'
 install:
 - pip install -r requirements.txt
 - pip install -r test_requirements.txt


### PR DESCRIPTION


- Python 2.7 is dead in a month or so.
- Travis CI breaks on 3.3 (can't download it)
- Python 3.4 shouldn't be alive and it's not even supported by major linux
distros.

